### PR TITLE
Add `npm` packages to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,19 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: pip
     directories:
-      - "/"
-      - "/core/base"
+      - /
+      - /docs
+      - /core/base
+      - /tests
     schedule:
-      interval: "daily"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      interval: daily
+  - package-ecosystem: npm
+    directory: /core/admin/assets
     schedule:
-      interval: "daily"
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
## Enhancement

This pull request enhances the following feature(s):
- Add `npm` packages used for bundling assets of the admin panel to the dependabot config.

## Details of Implementation

### What's new

- `npm` based packages now get checked for vulnerabilities and updates

### Previous behavior

- `npm` packages were ignored by Dependabot

## Checklist

Before we can consider review and merge, please make sure the following list is done and checked.

- [x] Make sure you follow our [Code of Conduct](https://github.com/heviat/Mailu-OIDC/blob/master/CODE_OF_CONDUCT.md).
- [x] This enhancement is tested and works as expected.
- [x] This enhancement modifies existing functionality[^1].
- [x] This enhancement does not break any existing functionality, or breaks it intentionally (documented above).
- [x] Add a [Changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.

[^1]: If this pull request introduces new functionality, please create a new-feature pull request instead. If it only fixes a bug but does not otherwise modify behaviour, please create a bug-fix pull request instead.
