### PR TITLE
Option to control automatic user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ properties are needed in `mailu.env`:
 | `OIDC_CHANGE_PASSWORD_REDIRECT_URL`     | Defaults to provider issuer url appended by `/.well-known/change-password`.                                         | [https://`host`/pw-change]() |
 | `OIDC_USERNAME_CLAIM`                   | 	The OIDC claim used as the username. If the selected claim contains an email address, it will be used as is. If it is not an email (e.g., `sub`), the email address will be constructed as `<OIDC_USERNAME_CLAIM>@<OIDC_USER_DOMAIN>`. Defaults to `email`. | `email` \| `sub`
 | `OIDC_USER_DOMAIN`                      | The domain used when constructing an email from a non-email username (e.g., when `OIDC_USERNAME_CLAIM=sub`). Ignored if `OIDC_USERNAME_CLAIM` is already an email. Defaults to the value of `DOMAIN`. | `example.com`
+| `OIDC_ENABLE_USER_CREATION`             | If enabled, users who authenticate successfully but do not yet have an account will have one created for them. If disabled, only existing users can log in, and authentication will fail for users without a pre-existing account. Defaults to `True`. | `True` \| `False` |
 
 Here is a snippet for easy copy paste:
 

--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -60,6 +60,7 @@ DEFAULT_CONFIG = {
     'OIDC_REDIRECT_URL': None,
     'OIDC_USERNAME_CLAIM': 'email',
     'OIDC_USER_DOMAIN': None,
+    'OIDC_ENABLE_USER_CREATION': True,
     # Mail settings
     'DMARC_RUA': None,
     'DMARC_RUF': None,

--- a/core/admin/mailu/sso/views/base.py
+++ b/core/admin/mailu/sso/views/base.py
@@ -58,6 +58,10 @@ def login():
 
             user = models.User.get(username)
             if user is None:
+                if not app.config['OIDC_ENABLE_USER_CREATION']:
+                    flask.flash('User %s does not exist' % username, 'error')
+                    return render_oidc_template(form, fields)
+
                 user = models.User.create(username)
 
             flask.session.regenerate()


### PR DESCRIPTION
Currently, there is no option to control whether user accounts should be automatically created when a new user authenticates via OIDC. In environments where automatic account creation may not be desirable due to security, compliance, or administrative concerns, it is necessary to have the ability to disable this feature.

A new configuration value is introduced:

|             Property Name               |                                                      Description                                                    |           Example         |
| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------- |
| `OIDC_ENABLE_USER_CREATION`             | If enabled, users who authenticate successfully but do not yet have an account will have one created for them. If disabled, only existing users can log in, and authentication will fail for users without a pre-existing account. Defaults to `True`. | `True` \| `False` |T

Closes #65.