### PR TITLE
fix: correcly fallback to DOMAIN when OIDC_USER_DOMAIN is empty/none

### DIFF
--- a/core/admin/mailu/sso/views/base.py
+++ b/core/admin/mailu/sso/views/base.py
@@ -54,7 +54,7 @@ def login():
                 return render_oidc_template(form, fields)
             
             if '@' not in username:
-                username = username + '@' + app.config.get('OIDC_USER_DOMAIN', app.config['DOMAIN'])
+                username = username + '@' + (app.config['OIDC_USER_DOMAIN'] or app.config['DOMAIN'])
 
             user = models.User.get(username)
             if user is None:


### PR DESCRIPTION
The original intention with `dict.get` was to fallback to a default value if `OIDC_USER_DOMAIN` is not configured.

However `OIDC_USER_DOMAIN` is now set to `None` by default so it will always be in the config dict. Therefore `dict.get` will return `None` and ignore the second parameter. I rewrote the expression to correctly fallback to `app.config['DOMAIN']`.